### PR TITLE
Add `setCode` to testnet clients

### DIFF
--- a/packages/common-testnets/src/TestnetClient.ts
+++ b/packages/common-testnets/src/TestnetClient.ts
@@ -4,6 +4,7 @@ import {
   Address,
   ContractFunctionArgs,
   ContractFunctionName,
+  Hex,
   PartialBy,
   PublicActions,
   WalletClient,
@@ -15,6 +16,7 @@ export interface TestnetClient extends WalletClient, PublicActions, TestnetClien
   setErc20Balance(tkn: Address, usr: Address, amount: bigint): Promise<void>
   setBalance(usr: Address, amount: bigint): Promise<void>
   setStorageAt(addr: Address, slot: Hash, value: string): Promise<void>
+  setCode(addr: Address, code: Hex): Promise<void>
   snapshot(): Promise<string>
   revert(snapshotId: string): Promise<string> // @note: returns new snapshot id (may be the same as the input)
   mineBlocks(blocks: bigint): Promise<void>

--- a/packages/common-testnets/src/TestnetFactory.test.ts
+++ b/packages/common-testnets/src/TestnetFactory.test.ts
@@ -1,3 +1,4 @@
+import { CheckedAddress, Hex } from '@marsfoundation/common-universal'
 import { expect } from 'earl'
 import { after, before, describe, it } from 'mocha'
 import { base, mainnet } from 'viem/chains'
@@ -110,6 +111,16 @@ describe('TestnetFactory', () => {
           expect(await testnetClient.getChainId()).toEqual(expectedChainId)
 
           expect(testnetClient.chain).toEqual({ ...base, id: expectedChainId })
+        })
+
+        it('setCode works correctly', async () => {
+          const randomContract = CheckedAddress.random('contract')
+          const newBytecode = Hex('0x123456')
+
+          await testnetClient.setCode(randomContract, newBytecode)
+
+          const actualCode = await testnetClient.getCode({ address: randomContract })
+          expect(actualCode).toEqual(newBytecode)
         })
       })
     })

--- a/packages/common-testnets/src/TestnetFactory.ts
+++ b/packages/common-testnets/src/TestnetFactory.ts
@@ -4,6 +4,7 @@ import { TestnetClient } from './TestnetClient.js'
 export interface TestnetCreateResult {
   client: TestnetClient
   rpcUrl: string
+  publicRpcUrl?: string // url that it's safe to leak as "cheat" methods like setting balances are disabled. Not all testnets supports this so it's optional
   cleanup: () => Promise<void>
 }
 /**

--- a/packages/common-testnets/src/helpers/getRandomChainId.ts
+++ b/packages/common-testnets/src/helpers/getRandomChainId.ts
@@ -1,0 +1,6 @@
+/**
+ * Use to generate a chainId with low probability of colliding with real network
+ */
+export function getRandomChainId(originChainId: number): number {
+  return Number.parseInt(`${originChainId}3030${Date.now()}`)
+}

--- a/packages/common-testnets/src/helpers/index.ts
+++ b/packages/common-testnets/src/helpers/index.ts
@@ -1,1 +1,2 @@
 export { replaceSafeOwner } from './replaceSafeOwner.js'
+export { getRandomChainId } from './getRandomChainId.js'

--- a/packages/common-testnets/src/nodes/anvil/AnvilClient.ts
+++ b/packages/common-testnets/src/nodes/anvil/AnvilClient.ts
@@ -1,5 +1,5 @@
 import { assert, Hash } from '@marsfoundation/common-universal'
-import { http, Address, Chain, createTestClient, numberToHex, publicActions, walletActions } from 'viem'
+import { http, Address, Chain, Hex, createTestClient, numberToHex, publicActions, walletActions } from 'viem'
 import { dealActions } from 'viem-deal'
 import { TestnetClient } from '../../TestnetClient.js'
 import { extendWithTestnetHelpers } from '../extendWithTestnetHelpers.js'
@@ -62,6 +62,12 @@ export function getAnvilClient(rpc: string, chain: Chain, forkChainId: number): 
             method: 'evm_setNextBlockTimestamp',
             params: [numberToHex(timestamp)],
           })
+        },
+        async setCode(addr: Address, code: Hex): Promise<void> {
+          await c.request({
+            method: 'anvil_setCode',
+            params: [addr.toString(), code],
+          } as any)
         },
       }
     })

--- a/packages/common-testnets/src/nodes/tenderly/TenderlyClient.ts
+++ b/packages/common-testnets/src/nodes/tenderly/TenderlyClient.ts
@@ -1,5 +1,5 @@
 import { Hash } from '@marsfoundation/common-universal'
-import { http, Address, Chain, createTestClient, numberToHex, publicActions, walletActions } from 'viem'
+import { http, Address, Chain, Hex, createTestClient, numberToHex, publicActions, walletActions } from 'viem'
 import { TestnetClient } from '../../TestnetClient.js'
 import { extendWithTestnetHelpers } from '../extendWithTestnetHelpers.js'
 
@@ -54,6 +54,12 @@ export function getTenderlyClient(rpcUrl: string, chain: Chain, forkChainId: num
           await c.request({
             method: 'tenderly_setNextBlockTimestamp',
             params: [numberToHex(timestamp)],
+          } as any)
+        },
+        async setCode(addr: Address, code: Hex): Promise<void> {
+          await c.request({
+            method: 'tenderly_setCode',
+            params: [addr.toString(), code],
           } as any)
         },
       }

--- a/packages/common-testnets/src/nodes/tenderly/TenderlyTestnetFactory.ts
+++ b/packages/common-testnets/src/nodes/tenderly/TenderlyTestnetFactory.ts
@@ -69,6 +69,7 @@ export class TenderlyTestnetFactory implements TestnetFactory {
     return {
       client,
       rpcUrl: adminRpc.url,
+      publicRpcUrl: publicRpc.url,
       cleanup: () => Promise.resolve(),
     }
   }


### PR DESCRIPTION
Changes needed for `spell-caster` to migrate to using common packages.