### PR TITLE
Add `no-unused-expressions` ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ module.exports = tseslint.config(
         { allowExpressions: true, allowDirectConstAssertionInArrowFunctions: true },
       ],
       'object-shorthand': 'error',
+      'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
     },
   },
   {
@@ -38,6 +39,7 @@ module.exports = tseslint.config(
       'func-style': ['error', 'declaration'],
       'object-shorthand': 'error',
       '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+      'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
     },
   },
 )


### PR DESCRIPTION
Added [allowShortCircuit and allowTernary](https://eslint.org/docs/latest/rules/no-unused-expressions#allowshortcircuit-and-allowternary) for [this occurrences](https://github.com/sparkdotfi/spark-app/blob/f79c3c85420f5c029a20ccfdb6add84e58306803/packages/app/src/features/actions/flavours/permit/logic/useCreatePermitHandler.ts#L89) to pass.