### PR TITLE
Add `hasBaselineSnapshot` testnet method

### DIFF
--- a/packages/common-testnets/src/TestnetClient.test.ts
+++ b/packages/common-testnets/src/TestnetClient.test.ts
@@ -1,0 +1,81 @@
+import { CheckedAddress, Hex } from '@marsfoundation/common-universal'
+import { expect } from 'earl'
+import { describe, it } from 'mocha'
+import { parseGwei } from 'viem'
+import { base } from 'viem/chains'
+import { TestnetClient } from './TestnetClient.js'
+import { createTestnetFactoriesForE2ETests } from './test-utils/index.js'
+
+describe('TestnetClient', () => {
+  const factories = createTestnetFactoriesForE2ETests()
+
+  for (const factory of factories) {
+    describe(`${factory.constructor.name} client`, () => {
+      const expectedChainId = 2137
+      let testnetClient: TestnetClient
+      let cleanup: () => Promise<void>
+
+      beforeEach(async () => {
+        ;({ client: testnetClient, cleanup } = await factory.create({
+          id: 'test',
+          originChain: base,
+          forkChainId: expectedChainId,
+        }))
+      })
+
+      afterEach(async () => {
+        await cleanup()
+      })
+
+      it('has correct chain id', async () => {
+        expect(await testnetClient.getChainId()).toEqual(expectedChainId)
+
+        expect(testnetClient.chain).toEqual({ ...base, id: expectedChainId })
+      })
+
+      it('setCode works correctly', async () => {
+        const randomContract = CheckedAddress.random('contract')
+        const newBytecode = Hex('0x123456')
+
+        await testnetClient.setCode(randomContract, newBytecode)
+
+        const actualCode = await testnetClient.getCode({ address: randomContract })
+        expect(actualCode).toEqual(newBytecode)
+      })
+
+      it('sets next block base fee correctly', async () => {
+        const baseFee = parseGwei('100')
+        if (factory.constructor.name === 'TenderlyTestnetFactory') {
+          await expect(testnetClient.setNextBlockBaseFee(baseFee)).toBeRejectedWith('Method not supported')
+          return
+        }
+
+        await testnetClient.setNextBlockBaseFee(baseFee)
+        await testnetClient.mineBlocks(1n)
+
+        const nextBlock = await testnetClient.getBlock()
+        const nextBaseFee = nextBlock.baseFeePerGas
+        expect(nextBaseFee).toEqual(baseFee)
+      })
+
+      describe('baseline snapshots', () => {
+        it('can create and revert to baseline snapshot', async () => {
+          await testnetClient.baselineSnapshot()
+          const currentBlockNumber = await testnetClient.getBlockNumber()
+          await testnetClient.mineBlocks(1n)
+          expect(await testnetClient.getBlockNumber()).toEqual(currentBlockNumber + 1n)
+
+          await testnetClient.revertToBaseline()
+          expect(await testnetClient.getBlockNumber()).toEqual(currentBlockNumber)
+        })
+
+        it('hasBaseline works', async () => {
+          expect(testnetClient.hasBaselineSnapshot()).toEqual(false)
+
+          await testnetClient.baselineSnapshot()
+          expect(testnetClient.hasBaselineSnapshot()).toEqual(true)
+        })
+      })
+    })
+  }
+})

--- a/packages/common-testnets/src/TestnetClient.ts
+++ b/packages/common-testnets/src/TestnetClient.ts
@@ -27,6 +27,7 @@ export interface TestnetClient extends WalletClient, PublicActions, TestnetClien
 export type TestnetClientHelperActions = {
   baselineSnapshot(): Promise<void> // @note: baseline snapshot can be created only once, useful to easily revert to a known state. Helper on top of the snapshot method
   revertToBaseline(): Promise<void> // @note: revert to the baseline snapshot, helper on top of the revert method
+  hasBaselineSnapshot(): boolean
 
   assertWriteContract: <
     const abi extends Abi | readonly unknown[],

--- a/packages/common-testnets/src/TestnetFactory.test.ts
+++ b/packages/common-testnets/src/TestnetFactory.test.ts
@@ -1,8 +1,6 @@
-import { CheckedAddress, Hex } from '@marsfoundation/common-universal'
 import { expect } from 'earl'
 import { after, before, describe, it } from 'mocha'
-import { parseGwei } from 'viem'
-import { base, mainnet } from 'viem/chains'
+import { mainnet } from 'viem/chains'
 import { TestnetClient } from './TestnetClient.js'
 import { createTestnetFactoriesForE2ETests } from './test-utils/index.js'
 
@@ -90,53 +88,6 @@ describe('TestnetFactory', () => {
         it('can fetch block number', async () => {
           const currentBlockNumber = await testnetClient.getBlockNumber()
           expect(currentBlockNumber).toBeGreaterThan(21385842n)
-        })
-      })
-
-      describe('client', () => {
-        let testnetClient: TestnetClient
-        let cleanup: () => Promise<void>
-
-        before(async () => {
-          ;({ client: testnetClient, cleanup } = await factory.create({
-            id: 'test',
-            originChain: base,
-            forkChainId: expectedChainId,
-          }))
-        })
-        after(async () => {
-          await cleanup()
-        })
-
-        it('has correct chain id', async () => {
-          expect(await testnetClient.getChainId()).toEqual(expectedChainId)
-
-          expect(testnetClient.chain).toEqual({ ...base, id: expectedChainId })
-        })
-
-        it('setCode works correctly', async () => {
-          const randomContract = CheckedAddress.random('contract')
-          const newBytecode = Hex('0x123456')
-
-          await testnetClient.setCode(randomContract, newBytecode)
-
-          const actualCode = await testnetClient.getCode({ address: randomContract })
-          expect(actualCode).toEqual(newBytecode)
-        })
-
-        it('sets next block base fee correctly', async () => {
-          const baseFee = parseGwei('100')
-          if (factory.constructor.name === 'TenderlyTestnetFactory') {
-            await expect(testnetClient.setNextBlockBaseFee(baseFee)).toBeRejectedWith('Method not supported')
-            return
-          }
-
-          await testnetClient.setNextBlockBaseFee(baseFee)
-          await testnetClient.mineBlocks(1n)
-
-          const nextBlock = await testnetClient.getBlock()
-          const nextBaseFee = nextBlock.baseFeePerGas
-          expect(nextBaseFee).toEqual(baseFee)
         })
       })
     })

--- a/packages/common-testnets/src/nodes/extendWithTestnetHelpers.ts
+++ b/packages/common-testnets/src/nodes/extendWithTestnetHelpers.ts
@@ -4,7 +4,7 @@ import { TestnetClient, TestnetClientHelperActions } from '../TestnetClient.js'
 export function extendWithTestnetHelpers(
   c: Pick<TestnetClient, 'snapshot' | 'revert' | 'writeContract' | 'waitForTransactionReceipt' | 'sendTransaction'>,
 ): TestnetClientHelperActions {
-  let baselineSnapshotId: string | undefined
+  let baselineSnapshotId: string | undefined = undefined
 
   return {
     async baselineSnapshot() {
@@ -16,6 +16,9 @@ export function extendWithTestnetHelpers(
       assert(baselineSnapshotId !== undefined, 'baseline snapshot not created')
 
       baselineSnapshotId = await c.revert(baselineSnapshotId)
+    },
+    hasBaselineSnapshot() {
+      return baselineSnapshotId !== undefined
     },
     async assertWriteContract(args) {
       const txHash = await c.writeContract(args as any)


### PR DESCRIPTION
Moved client methods test to a separate file. We should increase test coverage there. 