### PR TITLE
Improve `ZodString` detection

### DIFF
--- a/packages/common-universal/src/httpClient/HttpClient.ts
+++ b/packages/common-universal/src/httpClient/HttpClient.ts
@@ -29,7 +29,7 @@ export class HttpClient {
       throw new HttpError('POST', url, result.status, await result.text())
     }
 
-    if (schema instanceof ZodString) {
+    if (isZodString(schema)) {
       return await result.text()
     }
     return schema.parse(await result.json())
@@ -45,7 +45,7 @@ export class HttpClient {
       throw new HttpError('GET', url, result.status, await result.text())
     }
 
-    if (schema instanceof ZodString) {
+    if (isZodString(schema)) {
       return schema.parse(await result.text())
     }
     return schema.parse(await result.json())
@@ -66,4 +66,8 @@ export class HttpError extends Error {
 
 const applicationJsonHeader = {
   'Content-Type': 'application/json',
+}
+
+function isZodString<T extends z.ZodTypeAny>(schema: T): boolean {
+  return schema instanceof ZodString || schema._def.typeName === 'ZodString'
 }

--- a/packages/common-universal/src/httpClient/HttpClient.ts
+++ b/packages/common-universal/src/httpClient/HttpClient.ts
@@ -68,6 +68,6 @@ const applicationJsonHeader = {
   'Content-Type': 'application/json',
 }
 
-function isZodString<T extends z.ZodTypeAny>(schema: T): boolean {
+function isZodString(schema: z.ZodTypeAny): schema is ZodString {
   return schema instanceof ZodString || schema._def.typeName === 'ZodString'
 }


### PR DESCRIPTION
For some reason `instanceof` check didn't work in dns-sentinel even though I was using the same Zod version. I added additional check for `typeName` which solved the problem